### PR TITLE
revert: "feat: mark javax annotations scope as provided"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -162,10 +162,6 @@
         <groupId>javax.annotation</groupId>
         <artifactId>javax.annotation-api</artifactId>
         <version>${javax.annotations.version}</version>
-        <!-- Marking the scope as provided since retention=SOURCE
-            https://docs.oracle.com/javase/7/docs/api/javax/annotation/Generated.html
-            -->
-        <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
Reverts googleapis/java-shared-dependencies#70

This is breaking downstream dependencies tests.