### PR TITLE
build: use bom versioning release strategy

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,2 +1,2 @@
-releaseType: java-yoshi
+releaseType: java-bom
 bumpMinorPreMajor: true

--- a/synth.py
+++ b/synth.py
@@ -21,5 +21,6 @@ java.common_templates(excludes=[
   'samples/*',
   'renovate.json',
   # excluding samples ci jobs since there are no samples in this repo
-  '.github/workflows/samples.yaml'
+  '.github/workflows/samples.yaml',
+  '.github/release-please.yml',
 ])


### PR DESCRIPTION
This will now bump the minor version if a dependency updated its minor or major version.
