### PR TITLE
feat: add jackson-core to the list of managed dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -189,6 +189,8 @@
         <groupId>com.fasterxml.jackson</groupId>
         <artifactId>jackson-bom</artifactId>
         <version>${jackson.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
 
       <!-- TODO: replace with opencensus-bom when available -->

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,7 @@
     <opencensus.version>0.24.0</opencensus.version>
     <findbugs.version>3.0.2</findbugs.version>
     <errorprone.version>2.4.0</errorprone.version>
+    <jackson.version>2.11.3</jackson.version>
   </properties>
 
   <dependencyManagement>
@@ -183,6 +184,11 @@
         <groupId>com.google.errorprone</groupId>
         <artifactId>error_prone_annotations</artifactId>
         <version>${errorprone.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-core</artifactId>
+        <version>${jackson.version}</version>
       </dependency>
 
       <!-- TODO: replace with opencensus-bom when available -->

--- a/pom.xml
+++ b/pom.xml
@@ -186,8 +186,8 @@
         <version>${errorprone.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-core</artifactId>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
         <version>${jackson.version}</version>
       </dependency>
 


### PR DESCRIPTION
Although `com.fasterxml.jackson.core:jackson-core` is not a commonly used direct dependency in client libraries, it is a common transitive dependency in many clients. We occasionally run into errors like below in java-bigquery and java-notification:
```
Require upper bound dependencies error for com.fasterxml.jackson.core:jackson-core:2.11.1 paths to dependency are:
+-com.google.cloud:google-cloud-bigquery:1.122.3-SNAPSHOT
  +-com.google.cloud:google-cloud-storage:1.113.1
    +-com.fasterxml.jackson.core:jackson-core:2.11.1
and
+-com.google.cloud:google-cloud-bigquery:1.122.3-SNAPSHOT
  +-com.google.http-client:google-http-client-jackson2:1.37.0
    +-com.fasterxml.jackson.core:jackson-core:2.11.3
]
```
We think it would be best for us to manage the version of `com.fasterxml.jackson.core:jackson-core` to ensure that we don't run into dependency conflicts during updates.