### PR TITLE
deps: update gax.version to v1.60.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <site.installationModule>${project.artifactId}</site.installationModule>
 
     <grpc.version>1.33.1</grpc.version>
-    <gax.version>1.60.0</gax.version>
+    <gax.version>1.60.1</gax.version>
     <guava.version>30.0-android</guava.version>
     <protobuf.version>3.13.0</protobuf.version>
     <google.api-common.version>1.10.1</google.api-common.version>


### PR DESCRIPTION
com.google.api:gax-grpc 1.60.0 -> 1.60.1 patch
com.google.api:gax-bom 1.60.0 -> 1.60.1 patch

See gax release PR here: https://github.com/googleapis/gax-java/pull/1239