### PR TITLE
feat: add grpc-gcp to dependencyManagement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
 
     <grpc.version>1.38.1</grpc.version>
     <gax.version>1.65.1</gax.version>
+    <grpc-gcp.version>1.0.0</grpc-gcp.version>
     <guava.version>30.1.1-android</guava.version>
     <protobuf.version>3.17.3</protobuf.version>
     <google.api-common.version>1.10.4</google.api-common.version>
@@ -92,6 +93,11 @@
         <version>${gax.version}</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>grpc-gcp</artifactId>
+        <version>${grpc-gcp.version}</version>
       </dependency>
       <dependency>
         <groupId>com.google.guava</groupId>


### PR DESCRIPTION
Add gRPC-GCP extension library to shared dependencies.

This will be used by the Spanner client first: https://github.com/googleapis/java-spanner/pull/1227