### PR TITLE
deps: downgrade protobuf to 3.17.3 (not the latest 3.18.0)

### DIFF
--- a/first-party-dependencies/pom.xml
+++ b/first-party-dependencies/pom.xml
@@ -62,7 +62,7 @@
     <protobuf.version>3.17.3</protobuf.version>
     <google.api-common.version>2.0.2</google.api-common.version>
     <google.common-protos.version>2.5.0</google.common-protos.version>
-    <google.core.version>2.1.4</google.core.version>
+    <google.core.version>2.1.3</google.core.version>
     <google.auth.version>1.1.0</google.auth.version>
     <google.http-client.version>1.40.0</google.http-client.version>
     <google.oauth-client.version>1.32.1</google.oauth-client.version>

--- a/first-party-dependencies/pom.xml
+++ b/first-party-dependencies/pom.xml
@@ -59,7 +59,7 @@
     <gax.version>2.4.1</gax.version>
     <grpc-gcp.version>1.1.0</grpc-gcp.version>
     <guava.version>30.1.1-jre</guava.version>
-    <protobuf.version>3.18.0</protobuf.version>
+    <protobuf.version>3.17.3</protobuf.version>
     <google.api-common.version>2.0.2</google.api-common.version>
     <google.common-protos.version>2.5.0</google.common-protos.version>
     <google.core.version>2.1.4</google.core.version>


### PR DESCRIPTION
@Neenu1995 This version is the same as the version in the last release of the shared-dependencies BOM. 

https://search.maven.org/artifact/com.google.cloud/first-party-dependencies/2.2.1/pom