### PR TITLE
ci: version-check to run only for release-please PR

### DIFF
--- a/.github/workflows/version-check.yaml
+++ b/.github/workflows/version-check.yaml
@@ -8,6 +8,7 @@ jobs:
   upper-bound-check:
     name: Upper-bound check
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'googleapis' && github.head_ref == 'release-please--branches--main'
     steps:
       - uses: actions/checkout@v2
       - uses: stCarolas/setup-maven@v4
@@ -25,6 +26,7 @@ jobs:
   grpc-convergence-check:
     name: gRPC dependency convergence check
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'googleapis' && github.head_ref == 'release-please--branches--main'
     steps:
     - uses: actions/checkout@v2
     - uses: stCarolas/setup-maven@v4


### PR DESCRIPTION
While updating multiple dependencies in the BOM, it's ok to have inconsistent versions. But we want to ensure the consistent versioning when we make a release of the BOM.

I copied the setting from https://github.com/googleapis/java-cloud-bom/blob/main/.github/workflows/full-convergence-check.yaml#L10