### PR TITLE
deps: guava 31.1

### DIFF
--- a/first-party-dependencies/pom.xml
+++ b/first-party-dependencies/pom.xml
@@ -58,7 +58,7 @@
     <grpc.version>1.45.0</grpc.version>
     <gax.version>2.12.2</gax.version>
     <grpc-gcp.version>1.1.0</grpc-gcp.version>
-    <guava.version>31.0.1-jre</guava.version>
+    <guava.version>31.1-jre</guava.version>
     <protobuf.version>3.19.4</protobuf.version>
     <google.api-common.version>2.1.4</google.api-common.version>
     <google.common-protos.version>2.7.4</google.common-protos.version>


### PR DESCRIPTION
@Neenu1995 @blakeli0 As per discussion, manually upgrading the Guava version. Somehow RenovateBot didn't create a pull reqest.

(Note that the Guava had dropped Java 7 bytecode in version 31.0 already, [release note](https://github.com/google/guava/releases/tag/v31.0))