### PR TITLE
ci: no need to check native-image-support gRPC convergence

### DIFF
--- a/dependency-convergence-check/src/test/java/com/google/cloud/DependencyConvergenceTest.java
+++ b/dependency-convergence-check/src/test/java/com/google/cloud/DependencyConvergenceTest.java
@@ -57,7 +57,11 @@ public class DependencyConvergenceTest {
             "opencensus-exporter-stats-stackdriver",
             // Because grpc-gcp's gRPC version does not use version range notation, it does not
             // break downstream build
-            "grpc-gcp"));
+            "grpc-gcp",
+            // Because native-image-support's gRPC dependency is provided scope, it does not bring
+            // inconsistent gRPC artifacts to users' class paths.
+            "native-image-support"
+            ));
   }
 
   /**

--- a/dependency-convergence-check/src/test/java/com/google/cloud/DependencyConvergenceTest.java
+++ b/dependency-convergence-check/src/test/java/com/google/cloud/DependencyConvergenceTest.java
@@ -60,8 +60,7 @@ public class DependencyConvergenceTest {
             "grpc-gcp",
             // Because native-image-support's gRPC dependency is provided scope, it does not bring
             // inconsistent gRPC artifacts to users' class paths.
-            "native-image-support"
-            ));
+            "native-image-support"));
   }
 
   /**


### PR DESCRIPTION
I found https://github.com/googleapis/java-shared-dependencies/pull/665#issuecomment-1099189483 complains old gRPC version declared by "com.google.cloud:native-image-support" (provided scope). The artifact's gRPC dependency is irrelevant to users.