### PR TITLE
deps: google-cloud-core 2.8.12

### DIFF
--- a/first-party-dependencies/pom.xml
+++ b/first-party-dependencies/pom.xml
@@ -62,7 +62,7 @@
     <protobuf.version>3.21.6</protobuf.version>
     <google.api-common.version>2.2.1</google.api-common.version>
     <google.common-protos.version>2.9.2</google.common-protos.version>
-    <google.core.version>2.8.11</google.core.version>
+    <google.core.version>2.8.12</google.core.version>
     <google.auth.version>1.11.0</google.auth.version>
     <google.http-client.version>1.42.2</google.http-client.version>
     <google.oauth-client.version>1.34.1</google.oauth-client.version>


### PR DESCRIPTION
2.8.12 was released. It depends on gax 2.19.1