### PR TITLE
chore: upgrade native image downstream check to 22.2.0

### DIFF
--- a/.github/workflows/downstream-native-image.yaml
+++ b/.github/workflows/downstream-native-image.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        graalvm: [22.1.0, 22.0.0.2, 21.3.2]
+        graalvm: [22.2.0, 22.1.0]
         java: [11, 17]
         repo:
           # GAPIC library that doesn't use a real GCP project in integration tests


### PR DESCRIPTION
Upgrading version to 22.2.0 and also making matrix coverage consistent with https://github.com/googleapis/gax-java/blob/9cc2ccca2e7efca49bbcf928e554a028d2e77512/.github/workflows/downstream-native-image.yaml#L18
