### PR TITLE
chore(java): manually exclude requirements.txt from renovate bot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,7 @@
     ":maintainLockFilesDisabled",
     ":autodetectPinVersions"
   ],
+  "ignorePaths": [".kokoro/requirements.txt"],
   "packageRules": [
     {
       "packagePatterns": [


### PR DESCRIPTION
Manually brings in changes from https://github.com/googleapis/synthtool/pull/1594. [Renovate.json is excluded in owlbot](https://github.com/googleapis/java-shared-dependencies/blob/b39e6838c3f3f6ef2b350efe8aec1b622893421a/owlbot.py#L22) so the changes in synthtool couldn't be applied. This is to stop update dep PRs like [this one](https://github.com/googleapis/java-shared-dependencies/pull/859) from showing up in the repo.