### PR TITLE
deps: google-common-protos 2.8.4

### DIFF
--- a/first-party-dependencies/pom.xml
+++ b/first-party-dependencies/pom.xml
@@ -61,7 +61,7 @@
     <guava.version>31.1-jre</guava.version>
     <protobuf.version>3.19.6</protobuf.version>
     <google.api-common.version>2.1.5</google.api-common.version>
-    <google.common-protos.version>2.8.3</google.common-protos.version>
+    <google.common-protos.version>2.8.4</google.common-protos.version>
     <google.core.version>2.6.0</google.core.version>
     <google.auth.version>1.6.0</google.auth.version>
     <google.http-client.version>1.41.7</google.http-client.version>


### PR DESCRIPTION
 2.8.4 was just released. (Until it becomes available in Maven Central, the build will fail.)