### PR TITLE
deps: gRPC 1.45.3 in 2.10.x branch

### DIFF
--- a/first-party-dependencies/pom.xml
+++ b/first-party-dependencies/pom.xml
@@ -55,7 +55,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <site.installationModule>${project.artifactId}</site.installationModule>
-    <grpc.version>1.45.2</grpc.version>
+    <grpc.version>1.45.3</grpc.version>
     <gax.version>2.16.0</gax.version>
     <grpc-gcp.version>1.1.0</grpc-gcp.version>
     <guava.version>31.1-jre</guava.version>


### PR DESCRIPTION
Upgrading the gRPC version to the patch release of gRPC 1.45.3 (fix https://github.com/grpc/grpc-java/issues/9340), in the shared dependencies BOM 2.10.x branch.

