### PR TITLE
deps: auth library 1.6.1 on 2.10.x branch

### DIFF
--- a/first-party-dependencies/pom.xml
+++ b/first-party-dependencies/pom.xml
@@ -63,7 +63,7 @@
     <google.api-common.version>2.1.5</google.api-common.version>
     <google.common-protos.version>2.8.4</google.common-protos.version>
     <google.core.version>2.6.0</google.core.version>
-    <google.auth.version>1.6.0</google.auth.version>
+    <google.auth.version>1.6.1</google.auth.version>
     <google.http-client.version>1.41.7</google.http-client.version>
     <google.oauth-client.version>1.33.3</google.oauth-client.version>
     <google.api-client.version>1.34.0</google.api-client.version>


### PR DESCRIPTION
Incorporating auth library 1.6.1 release into 2.10.x branch https://github.com/googleapis/google-auth-library-java/releases/tag/v1.6.1