### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ Shared Maven dependencies for Google Cloud Java client libraries.
 This artifact is intended for Google-internal use, not for library users.
 
 :bus: In January 2023, this library has moved to
-[google-cloud-java/java-shared-dependencies](
-https://github.com/googleapis/google-cloud-java/tree/main/java-shared-dependencies).
+[gapic-generator-java/java-shared-dependencies](
+https://github.com/googleapis/gapic-generator-java/tree/main/java-shared-dependencies).
 This repository will be archived in the future.
-Future releases will appear in the new repository (https://github.com/googleapis/google-cloud-java/releases).
+Future releases will appear in the new repository (https://github.com/googleapis/gapic-generator-java/releases).
 The Maven artifact coordinates (such as `com.google.cloud:google-cloud-shared-dependencies`) remain the same.
 
 [![Maven][maven-version-image]][maven-version-link]


### PR DESCRIPTION
Updated link to new repo to reference gapic-generator-java

:bus: In January 2023, this library has moved to
[google-cloud-java/java-shared-dependencies](
https://github.com/googleapis/google-cloud-java/tree/main/java-shared-dependencies).
This repository will be archived in the future.
